### PR TITLE
make bool __tuple_all inline to avoid multiply defined symbols

### DIFF
--- a/include/tuple
+++ b/include/tuple
@@ -855,14 +855,14 @@ namespace __TUPLE_NAMESPACE
 
 
 __TUPLE_ANNOTATION
-  bool __tuple_all()
+  inline bool __tuple_all()
 {
   return true;
 }
 
 
 __TUPLE_ANNOTATION
-  bool __tuple_all(bool t)
+  inline bool __tuple_all(bool t)
 {
   return t;
 }


### PR DESCRIPTION
I tried including tuple in multiple .cpp files and got linker errors.  Making the non-templated overloads of __tuple_all inline seems to fix this issue.
