### PR TITLE
clang fix

### DIFF
--- a/demo.cpp
+++ b/demo.cpp
@@ -1,6 +1,6 @@
 #define __TUPLE_NAMESPACE foo
 
-#include <tuple>
+#include <tuple.hpp>
 #include <iostream>
 #include <cassert>
 

--- a/include/tuple.hpp
+++ b/include/tuple.hpp
@@ -61,7 +61,7 @@ namespace std
 {
 
 
-template<size_t, class> struct tuple_element;
+//template<size_t, class> struct tuple_element;
 
 
 template<size_t i>
@@ -82,7 +82,7 @@ struct tuple_element<i, __TUPLE_NAMESPACE::tuple<Type1,Types...>>
 };
 
 
-template<class> struct tuple_size;
+//template<class> struct tuple_size;
 
 
 template<class... Types>

--- a/include/tuple.hpp
+++ b/include/tuple.hpp
@@ -28,7 +28,7 @@
 
 #include <stddef.h> // XXX instead of <cstddef> to WAR clang issue
 #include <type_traits>
-#include <utility>
+#include <utility> // <utility> declares std::tuple_element et al. for us
 
 // allow the user to define an annotation to apply to these functions
 // by default, it attempts to be constexpr
@@ -61,9 +61,6 @@ namespace std
 {
 
 
-//template<size_t, class> struct tuple_element;
-
-
 template<size_t i>
 struct tuple_element<i, __TUPLE_NAMESPACE::tuple<>> {};
 
@@ -80,9 +77,6 @@ struct tuple_element<i, __TUPLE_NAMESPACE::tuple<Type1,Types...>>
 {
   using type = typename tuple_element<i - 1, __TUPLE_NAMESPACE::tuple<Types...>>::type;
 };
-
-
-//template<class> struct tuple_size;
 
 
 template<class... Types>


### PR DESCRIPTION
This seems to fix compilation error with clang, but not with ICC. Possible Intel C++ bug?

OSX:

```
$ clang++ demo.cpp -std=c++11 -Iinclude   && ./a.out
(no error)
$ clang++ demo.cpp -std=c++11 -Iinclude  -stdlib=libc++ && ./a.out
(no error)
$ g++-mp-4.9 demo.cpp -std=c++11 -Iinclude  && ./a.out
(no error)
$ icc demo.cpp -std=c++11 -Iinclude  && ./a.out
In file included from demo.cpp(3):
include/tuple.hpp(747): error: namespace "std" has no member "get"
      std::get(__TUPLE_NAMESPACE::tuple<UTypes...>& t);
           ^

In file included from demo.cpp(3):
include/tuple.hpp(753): error: namespace "std" has no member "get"
      std::get(const __TUPLE_NAMESPACE::tuple<UTypes...>& t);
           ^

In file included from demo.cpp(3):
include/tuple.hpp(759): error: namespace "std" has no member "get"
      std::get(__TUPLE_NAMESPACE::tuple<UTypes...>&& t);
           ^

compilation aborted for demo.cpp (code 2)
```

Ubuntu 14.04LTS

```
$ clang++-3.5 demo.cpp -std=c++11 -Iinclude && ./a.out
(no error)
$ clang++-3.5 demo.cpp -std=c++11 -Iinclude -stdlib=libc++ && ./a.out
(no error)
$ g++-4.9 demo.cpp -std=c++11 -Iinclude && ./a.out
(no error)
$ icc demo.cpp -std=c++11 -Iinclude && ./a.out
a.out: demo.cpp:157: int main(): Assertion `a == 1' failed.
```
